### PR TITLE
Rename chat topics and Scale up topic partitions

### DIFF
--- a/BigQuery/app.yaml
+++ b/BigQuery/app.yaml
@@ -4,7 +4,7 @@ variables:
   - name: input
     inputType: InputTopic
     description: This is the input topic
-    defaultValue: sentiment
+    defaultValue: chat-with-sentiment
     required: true
   - name: PROJECT_ID
     inputType: FreeText

--- a/Sentiment Demo UI/app.yaml
+++ b/Sentiment Demo UI/app.yaml
@@ -9,7 +9,7 @@ variables:
   - name: messages
     inputType: FreeText
     description: The topic to read from
-    defaultValue: messages
+    defaultValue: chat-messages
     required: true
   - name: drafts
     inputType: FreeText

--- a/Sentiment Demo UI/app.yaml
+++ b/Sentiment Demo UI/app.yaml
@@ -4,7 +4,7 @@ variables:
   - name: sentiment
     inputType: FreeText
     description: The topic to read from
-    defaultValue: sentiment
+    defaultValue: chat-with-sentiment
     required: true
   - name: messages
     inputType: FreeText

--- a/Sentiment Demo UI/src/app/services/quix.service.ts
+++ b/Sentiment Demo UI/src/app/services/quix.service.ts
@@ -23,9 +23,9 @@ export class QuixService {
   private workingLocally = true; // set to true if working locally
   private token: string = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ik1qVTBRVE01TmtJNVJqSTNOVEpFUlVSRFF6WXdRVFF4TjBSRk56SkNNekpFUWpBNFFqazBSUSJ9.eyJodHRwczovL3F1aXguYWkvb3JnX2lkIjoiZGVtbyIsImh0dHBzOi8vcXVpeC5haS9vd25lcl9pZCI6ImF1dGgwfGM1M2QzMzIxLTgwZDItNGQzYS1hNmU3LTdmYjY1NGM5YzJmMiIsImh0dHBzOi8vcXVpeC5haS90b2tlbl9pZCI6IjNjYzFjMTZhLTVlNmEtNGYwMC1iODhhLThhYzE5MzkwMDdlYiIsImh0dHBzOi8vcXVpeC5haS9leHAiOiIyMDk5MjU3MjAwIiwiaXNzIjoiaHR0cHM6Ly9hdXRoLnF1aXguYWkvIiwic3ViIjoiV3lmT3lRSmQ3Mk94WkJQQmRMUlpiVlYwSWVma0JyVXpAY2xpZW50cyIsImF1ZCI6InF1aXgiLCJpYXQiOjE2OTUxMjE2OTYsImV4cCI6MTY5NzcxMzY5NiwiYXpwIjoiV3lmT3lRSmQ3Mk94WkJQQmRMUlpiVlYwSWVma0JyVXoiLCJndHkiOiJjbGllbnQtY3JlZGVudGlhbHMiLCJwZXJtaXNzaW9ucyI6W119.b_6WtwsjuQklXeZA7TpUmWbOQ9xr0bpJ_3xfyZjSc0lLVhH3aAUrci1ofUFajTOCkes-6uhe_Bu9zD5fQimpKvCJ4fplIjRGXQSuFz9aiH2AOUZD2BOLaQZipmzgEjkNnomqwLCuE3f8Q2026lm3B685XHCHt7YiCHt3JdW4yOVjiJZjAfNd4stJUtAWeTUl7og1gN9SuBMQ9Z3zHjO2TBQieQ2xAI812MbAaGDd7TWKkvPlMgdxApe6bu5nMCaE7_HLrSGNBKnkQ_Z_TTFiW_e9yaAmOojtANn2Jx21-OWfEg9aG8-FcoNSjkCaD3JTSTk0MNHEEuLGmpowxzZmGg'; // Create a token in the Tokens menu and paste it here
   public workspaceId: string = 'demo-chatappdemo-newfeui'; // Look in the URL for the Quix Portal your workspace ID is after 'workspace='
-  public messagesTopic: string = 'messages'; // get topic name from the Topics page
+  public messagesTopic: string = 'chat-messages'; // get topic name from the Topics page
   public draftsTopic: string = 'drafts'; // get topic from the Topics page
-  public sentimentTopic: string = 'sentiment'; // get topic name from the Topics page
+  public sentimentTopic: string = 'chat-with-sentiment'; // get topic name from the Topics page
   public draftsSentimentTopic: string = 'drafts_sentiment'; // get topic name from the Topics page
   /*~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-*/
 

--- a/Sentiment analysis/app.yaml
+++ b/Sentiment analysis/app.yaml
@@ -9,7 +9,7 @@ variables:
   - name: output
     inputType: OutputTopic
     description: This is the output for the Hugging Face model score
-    defaultValue: sentiment
+    defaultValue: chat-with-sentiment
     required: true
 dockerfile: build/dockerfile
 runEntryPoint: main.py

--- a/Sentiment analysis/app.yaml
+++ b/Sentiment analysis/app.yaml
@@ -4,7 +4,7 @@ variables:
   - name: input
     inputType: InputTopic
     description: This is the raw data input topic
-    defaultValue: messages
+    defaultValue: chat-messages
     required: true
   - name: output
     inputType: OutputTopic

--- a/Twitch Chat/app.yaml
+++ b/Twitch Chat/app.yaml
@@ -4,7 +4,7 @@ variables:
   - name: output
     inputType: OutputTopic
     description: Name of the output topic to write messages into
-    defaultValue: messages
+    defaultValue: chat-messages
     required: true
   - name: TwitchBotToken
     inputType: HiddenText

--- a/quix.yaml
+++ b/quix.yaml
@@ -9,7 +9,7 @@ deployments:
   - name: Sentiment analysis
     application: Sentiment analysis
     deploymentType: Service
-    version: sa-v1-dev1
+    version: d49be638a568e2d209ec50a8eb2c6e2efbcc1e0f
     resources:
       cpu: 2000
       memory: 4000
@@ -20,12 +20,12 @@ deployments:
         inputType: InputTopic
         description: This is the raw data input topic
         required: true
-        value: messages
+        value: chat-messages
       - name: output
         inputType: OutputTopic
         description: This is the output for the Hugging Face model score
         required: true
-        value: sentiment
+        value: chat-with-sentiment
   - name: Drafts sentiment analysis
     application: Drafts sentiment analysis
     deploymentType: Service

--- a/quix.yaml
+++ b/quix.yaml
@@ -124,7 +124,7 @@ deployments:
   - name: Twitch Chat
     application: Twitch Chat
     deploymentType: Service
-    version: 5d726bf8f1a8902e7fe29afb80bcc8177d5f8330
+    version: d49be638a568e2d209ec50a8eb2c6e2efbcc1e0f
     resources:
       cpu: 2000
       memory: 1000
@@ -135,7 +135,7 @@ deployments:
         inputType: OutputTopic
         description: Name of the output topic to write messages into
         required: true
-        value: messages
+        value: chat-messages
       - name: StreamsToJoinCount
         inputType: FreeText
         description: Number of active stream channel to constantly be connected to

--- a/quix.yaml
+++ b/quix.yaml
@@ -159,13 +159,6 @@ deployments:
 
 # This section describes the Topics of the data pipeline
 topics:
-  - name: sentiment
-    persisted: false
-    configuration:
-      partitions: 16
-      replicationFactor: 2
-      retentionInMinutes: 120
-      retentionInBytes: 10485760
   - name: drafts
     persisted: false
     configuration:

--- a/quix.yaml
+++ b/quix.yaml
@@ -52,7 +52,7 @@ deployments:
   - name: Sentiment Demo UI
     application: Sentiment Demo UI
     deploymentType: Service
-    version: ee27a3601bddae54dfa70ebd55ba49655ae42186
+    version: 2064d51777f9381053ffd4d1f382d7c755643373
     resources:
       cpu: 1000
       memory: 500
@@ -66,12 +66,12 @@ deployments:
         inputType: FreeText
         description: The topic to read from
         required: true
-        value: sentiment
+        value: chat-with-sentiment
       - name: messages
         inputType: FreeText
         description: The topic to read from
         required: true
-        value: messages
+        value: chat-messages
       - name: drafts
         inputType: FreeText
         description: ''

--- a/quix.yaml
+++ b/quix.yaml
@@ -90,7 +90,7 @@ deployments:
       cpu: 1000
       memory: 1000
       replicas: 1
-    desiredStatus: Running
+    desiredStatus: Stopped
     variables:
       - name: input
         inputType: InputTopic

--- a/quix.yaml
+++ b/quix.yaml
@@ -194,3 +194,10 @@ topics:
       replicationFactor: 2
       retentionInMinutes: 120
       retentionInBytes: 524288000
+  - name: chat-with-sentiment
+    persisted: false
+    configuration:
+      partitions: 8
+      replicationFactor: 2
+      retentionInMinutes: 120
+      retentionInBytes: 524288000

--- a/quix.yaml
+++ b/quix.yaml
@@ -195,7 +195,7 @@ topics:
       retentionInMinutes: 120
       retentionInBytes: 524288000
   - name: chat-with-sentiment
-    persisted: false
+    persisted: true
     configuration:
       partitions: 8
       replicationFactor: 2

--- a/quix.yaml
+++ b/quix.yaml
@@ -90,7 +90,7 @@ deployments:
       cpu: 1000
       memory: 1000
       replicas: 1
-    desiredStatus: Stopped
+    desiredStatus: Running
     variables:
       - name: input
         inputType: InputTopic

--- a/quix.yaml
+++ b/quix.yaml
@@ -166,13 +166,6 @@ topics:
       replicationFactor: 2
       retentionInMinutes: 120
       retentionInBytes: 10485760
-  - name: messages
-    persisted: false
-    configuration:
-      partitions: 16
-      replicationFactor: 2
-      retentionInMinutes: 120
-      retentionInBytes: 104857600
   - name: drafts
     persisted: false
     configuration:

--- a/quix.yaml
+++ b/quix.yaml
@@ -116,7 +116,6 @@ deployments:
         inputType: HiddenText
         description: JSON string of the service account file for the BigQuery GCP project
         required: true
-        value: {{ BIG_QUERY_SERVIS_ACCOUNT_JSON }}
       - name: MAX_QUEUE_SIZE
         inputType: FreeText
         description: Max queue size for the sink ingestion
@@ -158,18 +157,17 @@ deployments:
         required: false
         value: TwitchAppClientSecret
 
-
 # This section describes the Topics of the data pipeline
 topics:
   - name: sentiment
-    persisted: true
+    persisted: false
     configuration:
       partitions: 16
       replicationFactor: 2
       retentionInMinutes: 120
       retentionInBytes: 10485760
   - name: messages
-    persisted: true
+    persisted: false
     configuration:
       partitions: 16
       replicationFactor: 2
@@ -189,3 +187,10 @@ topics:
       replicationFactor: 2
       retentionInMinutes: -1
       retentionInBytes: 262144000
+  - name: chat-messages
+    persisted: false
+    configuration:
+      partitions: 8
+      replicationFactor: 2
+      retentionInMinutes: 120
+      retentionInBytes: 524288000

--- a/quix.yaml
+++ b/quix.yaml
@@ -96,7 +96,7 @@ deployments:
         inputType: InputTopic
         description: This is the input topic
         required: true
-        value: sentiment
+        value: chat-with-sentiment
       - name: PROJECT_ID
         inputType: FreeText
         description: The BigQuery GCP Project ID

--- a/quix.yaml
+++ b/quix.yaml
@@ -188,7 +188,7 @@ topics:
       retentionInMinutes: -1
       retentionInBytes: 262144000
   - name: chat-messages
-    persisted: false
+    persisted: true
     configuration:
       partitions: 8
       replicationFactor: 2


### PR DESCRIPTION
Increase number or topic partitions for messages to 8 and sentiment topic to 8 as well.

Change the name of the topics as well. So lets call them chat-messages and chat-with-sentiment


